### PR TITLE
ci(root): Configure GitHub Actions CI for Turborepo (#45)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@
 #   │   • Sets up Node.js 20                              │
 #   │   • Installs all npm workspace dependencies         │
 #   │   • Runs lint across the monorepo via Turborepo     │
+#   │   • Runs unit tests across the monorepo             │
 #   │   • Builds packages/backend (Fastify / TypeScript)  │
 #   │   • Builds packages/frontend (Next.js)              │
 #   └─────────────────────────────────────────────────────┘
@@ -106,6 +107,11 @@ jobs:
       #    A non-zero exit code fails the job and blocks merging.
       - name: Lint (Turborepo)
         run: npx turbo run lint
+
+      # 4.5. Test — executes unit tests for the frontend and backend.
+      #      Satisfies Issue #45 Acceptance Criteria Step 2.
+      - name: Test (Turborepo)
+        run: npx turbo run test
 
       # 5. Build — compiles both the Fastify backend (tsc) and the Next.js
       #    frontend (next build). Turborepo respects the `dependsOn` graph in


### PR DESCRIPTION
## Description
This PR fully resolves Issue #45. While an excellent boilerplate CI file existed in the repo, it was missing the required JS/TS test execution step outlined in the issue's acceptance criteria.

This update injects the `npx turbo run test` command into the `node` job, ensuring that both the frontend and backend unit test suites must pass before any open-source PRs can be merged for Wave 4.

**Key Additions:**
- Added `npx turbo run test` to the Node.js job matrix in `.github/workflows/ci.yml`.

Closes #45

## Type of Change
- [x] DevOps / Infrastructure
- [x] CI/CD Pipeline

## Validation
- [x] Verified the YAML syntax remains valid.
- [x] The pipeline now explicitly guards against merging if frontend/backend unit tests fail.