### PR TITLE
feat(root): Implement Docker Compose for local full-stack development (#47)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,11 @@ HOST=0.0.0.0
 # Get a funded Testnet account at: https://developers.stellar.org/network/testnet/get-started
 # WARNING: Never use a Mainnet keypair here.
 DEPLOYER_SECRET=
+
+# ─── Database & Caching (Local Docker Setup) ─────────────────────────────────
+
+# PostgreSQL connection string
+DATABASE_URL="postgresql://postgres:password@localhost:5432/very_princess?schema=public"
+
+# Redis connection URL
+REDIS_URL="redis://localhost:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    container_name: very-princess-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: very_princess
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: very-princess-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "test": "turbo run test",
     "lint": "turbo run lint",
     "clean": "turbo run clean && rm -rf node_modules",
-    "format": "prettier --write \"**/*.{ts,tsx,js,json,md}\""
+    "format": "prettier --write \"**/*.{ts,tsx,js,json,md}\"",
+    "dev:infra": "docker compose up -d",
+    "stop:infra": "docker compose down"
   },
   "devDependencies": {
     "prettier": "^3.3.0",


### PR DESCRIPTION
## Description
This PR resolves Issue #47 by introducing a `docker-compose.yml` file to eliminate onboarding friction for new open-source contributors. 

Instead of forcing developers to manually install and configure PostgreSQL and Redis on their host machines, they can now spin up the entire isolated data layer with a single npm script.

**Key Additions:**
- **`docker-compose.yml`**: Provisions `postgres:15-alpine` and `redis:7-alpine` containers. Configured with persistent volumes so local data survives container restarts, and attached health checks for pipeline stability.
- **`package.json` Scripts**: Added `npm run dev:infra` to spin up the containers in detached mode, and `npm run stop:infra` to cleanly tear them down.
- **`.env.example`**: Appended local Docker connection strings for `DATABASE_URL` and `REDIS_URL` to ensure new contributors have the exact variables needed to connect the Fastify backend to the newly provisioned containers.

Closes #47

## Type of Change
- [x] DevOps / Infrastructure
- [x] Developer Experience (DX)

## Validation
- [x] Tested `npm run dev:infra` locally; containers start successfully and bind to standard ports (`5432`, `6379`).
- [x] Verified persistent volumes map correctly and data is retained between teardowns.
- [x] PR targets the `develop` branch as per `CONTRIBUTING.md` guidelines.