### PR TITLE
feat(backend): Dockerize the Fastify Backend (Multi-stage build) (#46)

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -1,0 +1,54 @@
+# ─── Stage 1: Base & Prune ───────────────────────────────────────────────────
+# Use the lightweight Alpine image
+FROM node:20-alpine AS base
+# Install libc6-compat for Turborepo native binaries
+RUN apk update && apk add --no-cache libc6-compat
+
+FROM base AS builder
+WORKDIR /app
+RUN npm install -g turbo
+COPY . .
+# Surgically extract only the backend package and its dependencies
+RUN turbo prune @very-princess/backend --docker
+
+# ─── Stage 2: Install & Build ────────────────────────────────────────────────
+FROM base AS installer
+WORKDIR /app
+
+# Install dependencies based on the pruned lockfile
+COPY --from=builder /app/out/json/ .
+COPY --from=builder /app/out/package-lock.json ./package-lock.json
+RUN npm ci
+
+# Copy the actual pruned source code
+COPY --from=builder /app/out/full/ .
+
+# PATCH: turbo prune drops root TS configs and hoisted Stellar SDK types.
+# We explicitly copy them from the builder and inject the missing types.
+COPY --from=builder /app/tsconfig*.json ./
+RUN npm install --no-save @types/urijs @types/json-schema
+
+# Build the backend
+RUN npx turbo run build --filter=@very-princess/backend...
+
+# ─── Stage 3: Production Runner ──────────────────────────────────────────────
+FROM base AS runner
+WORKDIR /app/packages/backend
+
+# Security: Create a non-root user to run the application
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 fastify
+USER fastify
+
+# Copy the hoisted root node_modules
+COPY --from=installer --chown=fastify:nodejs /app/node_modules /app/node_modules
+
+# Copy only the compiled production assets and package.json
+COPY --from=installer --chown=fastify:nodejs /app/packages/backend/package.json ./
+COPY --from=installer --chown=fastify:nodejs /app/packages/backend/dist ./dist
+
+# Expose the Fastify API port
+EXPOSE 3001
+
+# Start the compiled application
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Description
This PR resolves Issue #46 by introducing a highly optimized, multi-stage `Dockerfile` tailored for our Fastify backend within the Turborepo architecture.

To ensure consistency across staging and production without bloating the final image with frontend assets, this configuration leverages `turbo prune --scope=@very-princess/backend` to surgically extract only the required dependencies and source files.

**Key Additions:**
- **Multi-stage Build**: Split into `builder` (pruning), `installer` (compilation), and `runner` (production execution) stages.
- **Base Image**: Utilizes the lightweight `node:20-alpine` image to drastically reduce the container surface area.
- **Monorepo Patch**: Injects a patch to explicitly copy `tsconfig.base.json` and install hoisted `@stellar/stellar-sdk` type definitions (`@types/urijs`, `@types/json-schema`) that are normally stripped by Turborepo's aggressive pruning.
- **Security**: The final runner stage executes entirely under a non-root `fastify` user (uid 1001), adhering to secure container best practices.
- **Payload Optimization**: Only the compiled `/dist` directory and the hoisted root `node_modules` are copied into the final runner stage. *(Note: The issue ticket mentioned copying the Prisma schema, but as Prisma is not currently implemented in the `package.json`, this step was omitted to prevent build failures).*

Closes #46

## Type of Change
- [x] DevOps / Infrastructure
- [x] Security (Non-root user execution)

## Validation
- [x] Confirmed `turbo prune` successfully isolates backend dependencies.
- [x] Handled missing hoisted TS types during the build stage.
- [x] Correctly handled npm workspace hoisting by copying root `node_modules` and omitting non-existent local folders.