### PR TITLE
feat: resolve issues #64, #65, #66, #67 — security audits, admin rotation, semantic versioning, E2E containers

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,19 @@
+# Changesets
+
+This directory is managed by [@changesets/cli](https://github.com/changesets/changesets).
+
+## How to add a changeset
+
+Run the following command from the repo root and follow the prompts:
+
+```bash
+npx changeset
+```
+
+Select the packages that changed, choose the semver bump type (major/minor/patch), and write a summary. A new markdown file will be created in this directory.
+
+## Release flow
+
+1. Open a PR with your changes and a changeset file.
+2. When merged to `main`, the **Release** GitHub Action opens a "Version Packages" PR that bumps `package.json` versions and updates `CHANGELOG.md` files.
+3. Merging that PR publishes the new versions.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "restricted",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,13 @@
 # This workflow validates the entire very-princess monorepo on every push to
 # `main` and on every Pull Request targeting `main`.
 #
-# The pipeline is split into two parallel jobs that run concurrently:
+# The pipeline is split into three parallel jobs that run concurrently:
 #
 #   ┌─────────────────────────────────────────────────────┐
 #   │  JOB 1: node                                        │
 #   │   • Sets up Node.js 20                              │
 #   │   • Installs all npm workspace dependencies         │
+#   │   • Runs npm audit (fails on High/Critical CVEs)    │
 #   │   • Runs lint across the monorepo via Turborepo     │
 #   │   • Runs unit tests across the monorepo             │
 #   │   • Builds packages/backend (Fastify / TypeScript)  │
@@ -23,10 +24,18 @@
 #   │   • Adds the wasm32-unknown-unknown compilation     │
 #   │     target required by Soroban                      │
 #   │   • Installs the Stellar CLI for `contract build`   │
+#   │   • Installs cargo-audit and scans Cargo.lock       │
 #   │   • Runs `cargo fmt --check` (formatting lint)      │
 #   │   • Runs `cargo clippy` (Rust-idiomatic lint)       │
 #   │   • Runs `cargo test` (unit tests)                  │
 #   │   • Builds the optimised release WASM artefact      │
+#   └─────────────────────────────────────────────────────┘
+#
+#   ┌─────────────────────────────────────────────────────┐
+#   │  JOB 3: e2e                                         │
+#   │   • Spins up postgres:15 and redis:alpine services  │
+#   │   • Runs npx prisma migrate deploy                  │
+#   │   • Executes Fastify and Next.js E2E test suites    │
 #   └─────────────────────────────────────────────────────┘
 #
 # Turborepo remote caching is intentionally disabled in CI to keep the
@@ -77,7 +86,7 @@ jobs:
   # Turborepo to take advantage of task-graph dependency ordering and
   # build caching.
   node:
-    name: "Node.js — Lint, Build & Type-check"
+    name: "Node.js — Lint, Audit, Build & Type-check"
     runs-on: ubuntu-latest
 
     steps:
@@ -101,6 +110,12 @@ jobs:
       #    (`npm ci` instead of `npm install`) to guarantee reproducibility.
       - name: Install npm dependencies
         run: npm ci
+
+      # 3.5. Security audit — scans all npm workspace packages for known CVEs.
+      #      Fails the pipeline immediately if any High or Critical vulnerability
+      #      is found. Resolves Issue #64 (Automated Dependency Security Audits).
+      - name: npm audit (High/Critical CVEs)
+        run: npm audit --audit-level=high
 
       # 4. Lint — runs `eslint` across packages/backend and packages/frontend.
       #    Turborepo parallelises this across both packages automatically.
@@ -135,7 +150,7 @@ jobs:
   # Validates the PayoutRegistry smart contract written in Rust.
   # This job runs in parallel with `node` — neither depends on the other.
   contracts:
-    name: "Contracts — Fmt, Clippy, Test & Build"
+    name: "Contracts — Fmt, Clippy, Audit, Test & Build"
     runs-on: ubuntu-latest
 
     # All steps in this job default to the contracts package directory so
@@ -185,6 +200,14 @@ jobs:
             --version ${{ env.SOROBAN_CLI_VERSION }} \
             --features opt
 
+      # 4.5. Security audit — scans Cargo.lock for known CVEs in Rust crates.
+      #      Fails the pipeline immediately if any High or Critical advisory is
+      #      found. Resolves Issue #64 (Automated Dependency Security Audits).
+      - name: Install and run cargo-audit
+        run: |
+          cargo install --locked cargo-audit --version 0.21.0
+          cargo audit
+
       # 5. Formatting lint — ensures all Rust source code has been passed
       #    through `cargo fmt`. PRs with unformatted code are rejected here.
       - name: Check Rust formatting (cargo fmt)
@@ -212,3 +235,82 @@ jobs:
       #    overflows, linker errors with wasm-opt).
       - name: Build release WASM (stellar contract build)
         run: stellar contract build --profile release
+
+  # ── Job 3: Containerized E2E Testing ─────────────────────────────────────
+  # Spins up real postgres and redis service containers, runs Prisma
+  # migrations against the ephemeral DB, then executes the E2E test suites.
+  # Resolves Issue #67 (Containerized E2E Testing Environment).
+  e2e:
+    name: "E2E — Containerized Integration Tests"
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: very_princess_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/very_princess_test"
+      REDIS_URL: "redis://localhost:6379"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      # Run Prisma migrations against the ephemeral CI database before tests.
+      - name: Run Prisma migrations
+        run: npx prisma migrate deploy
+        working-directory: packages/backend
+
+      # Execute the Fastify backend E2E / integration test suite.
+      - name: Run backend E2E tests
+        run: npx turbo run test --filter=backend
+        env:
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+          REDIS_URL: ${{ env.REDIS_URL }}
+
+      # Execute the Next.js frontend E2E tests via Playwright.
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: packages/frontend
+
+      - name: Run frontend E2E tests (Playwright)
+        run: npx playwright test
+        working-directory: packages/frontend
+        env:
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+          REDIS_URL: ${{ env.REDIS_URL }}
+          NEXT_PUBLIC_CONTRACT_ID: "PLACEHOLDER_FOR_CI_BUILD"
+          NEXT_PUBLIC_RPC_URL: "https://soroban-testnet.stellar.org"
+          NEXT_PUBLIC_HORIZON_URL: "https://horizon-testnet.stellar.org"
+          NEXT_PUBLIC_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Release — Turborepo Semantic Versioning & Automated Changelogs
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# This workflow uses @changesets/cli to automate semantic versioning and
+# changelog generation across all packages in the Turborepo monorepo.
+#
+# Flow:
+#   1. On every push to `main`, the action checks for pending changesets.
+#   2. If changesets are found, it opens (or updates) a "Version Packages" PR
+#      that bumps package.json versions and appends release notes to CHANGELOG.md.
+#   3. When that PR is merged, the action publishes the updated packages.
+#
+# Resolves Issue #66 (Turborepo Semantic Versioning & Automated Changelogs).
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    name: "Version Packages or Publish"
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Full history is required by changesets to compute version bumps.
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The changesets action either:
+      #   • Opens/updates a "Version Packages" PR when changesets are present, or
+      #   • Publishes packages (runs `npm run release`) when the version PR is merged.
+      - name: Create Version PR or Publish
+        uses: changesets/action@v1
+        with:
+          # Command run when the version PR is merged to actually publish.
+          publish: npm run release
+          # Commit message used on the version bump commit.
+          commit: "chore: version packages"
+          # PR title for the automated version bump PR.
+          title: "chore: version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
     "staging:build": "NODE_ENV=staging turbo run build",
     "staging:deploy": "npm run staging:build && npm run staging:deploy:infra",
     "staging:deploy:infra": "docker-compose -f docker-compose.staging.yml up -d",
-    "staging:stop": "docker-compose -f docker-compose.staging.yml down"
+    "staging:stop": "docker-compose -f docker-compose.staging.yml down",
+    "release": "changeset publish"
   },
   "devDependencies": {
+    "@changesets/cli": "^2.27.1",
     "pino-pretty": "^13.1.3",
     "prettier": "^3.3.0",
     "turbo": "^2.0.0",

--- a/packages/contracts/src/lib.rs
+++ b/packages/contracts/src/lib.rs
@@ -67,6 +67,8 @@ pub enum DataKey {
     MultisigAdmin,
     /// Current protocol state (Active or Paused).
     ProtocolState,
+    /// Pending admin address proposed via propose_admin (two-step transfer).
+    PendingAdmin,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -667,6 +669,61 @@ impl PayoutRegistry {
         env.events().publish(
             (Symbol::new(&env, "VeryPrincess"), Symbol::new(&env, "ProtocolUnpaused")),
             env.ledger().timestamp(),
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Protocol Admin Rotation (two-step ownership transfer)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Step 1 of admin transfer: the current multisig admin proposes a new admin.
+    ///
+    /// The new admin is stored as `PendingAdmin` and must call `accept_admin` to
+    /// complete the transfer. This prevents accidentally transferring ownership to
+    /// an invalid or burned address.
+    ///
+    /// # Panics
+    /// * If multisig authorization is insufficient.
+    pub fn propose_admin(env: Env, new_admin: Address) {
+        Self::verify_multisig_auth(&env);
+        env.storage()
+            .persistent()
+            .set(&DataKey::PendingAdmin, &new_admin);
+        env.events().publish(
+            (Symbol::new(&env, "VeryPrincess"), Symbol::new(&env, "AdminProposed")),
+            new_admin,
+        );
+    }
+
+    /// Step 2 of admin transfer: the proposed new admin accepts ownership.
+    ///
+    /// Replaces the multisig admin list with a single-member list containing
+    /// `new_admin` and clears the pending admin slot.
+    ///
+    /// # Panics
+    /// * If there is no pending admin proposal.
+    /// * If the caller is not the pending admin.
+    pub fn accept_admin(env: Env, new_admin: Address) {
+        new_admin.require_auth();
+        let pending: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingAdmin)
+            .expect("no pending admin proposal");
+        if pending != new_admin {
+            panic!("caller is not the pending admin");
+        }
+        // Build a new single-member multisig with threshold 1
+        let mut admins = Vec::new(&env);
+        admins.push_back(new_admin.clone());
+        let multisig_admin = MultisigAdmin { admins, threshold: 1 };
+        env.storage()
+            .persistent()
+            .set(&DataKey::MultisigAdmin, &multisig_admin);
+        env.storage().persistent().remove(&DataKey::PendingAdmin);
+        env.events().publish(
+            (Symbol::new(&env, "VeryPrincess"), Symbol::new(&env, "admin_transferred")),
+            new_admin,
         );
     }
 


### PR DESCRIPTION
## Summary

Resolves all four issues assigned to @Xuccessor in a single PR.

---

### Closes #64 — Automated Dependency Security Audits

- Added `npm audit --audit-level=high` step to the `node` CI job. The pipeline fails immediately on any High or Critical npm CVE.
- Installed `cargo-audit` (pinned v0.21.0) and run `cargo audit` in the `contracts` CI job. The pipeline fails immediately on any High or Critical Rust advisory.

### Closes #65 — Soroban Admin Rotation & Ownership Transfer

Implemented a two-step ownership transfer in `packages/contracts/src/lib.rs`:

- Added `PendingAdmin` variant to the `DataKey` enum.
- `propose_admin(env, new_admin)` — requires multisig auth from the current admin set, stores the candidate in `PendingAdmin`, emits `AdminProposed`.
- `accept_admin(env, new_admin)` — requires auth from the pending admin, replaces `MultisigAdmin` with a single-member config, clears `PendingAdmin`, emits `admin_transferred`.

This prevents accidentally transferring ownership to an invalid or burned address.

### Closes #66 — Turborepo Semantic Versioning & Automated Changelogs

- Added `@changesets/cli ^2.27.1` as a root devDependency and a `release` script (`changeset publish`).
- Created `.changeset/config.json` (baseBranch: main, access: restricted).
- Created `.github/workflows/release.yml` using `changesets/action@v1`: opens a "Version Packages" PR when changesets are detected on `main`; merging that PR bumps `package.json` versions and appends release notes to `CHANGELOG.md`.

### Closes #67 — Containerized E2E Testing Environment

Added a new `e2e` job to `.github/workflows/ci.yml`:

- Spins up `postgres:15` and `redis:alpine` service containers with health checks.
- Sets `DATABASE_URL` pointing to `localhost:5432` with GitHub Actions default credentials.
- Runs `npx prisma migrate deploy` against the ephemeral CI database.
- Executes the Fastify backend E2E test suite via Turborepo.
- Installs Playwright Chromium and runs the Next.js frontend E2E suite.

---

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Added `npm audit`, `cargo-audit`, and new `e2e` job |
| `.github/workflows/release.yml` | New — changesets release workflow |
| `packages/contracts/src/lib.rs` | Added `PendingAdmin` DataKey, `propose_admin`, `accept_admin` |
| `package.json` | Added `@changesets/cli` devDep and `release` script |
| `.changeset/config.json` | New — changesets configuration |
| `.changeset/README.md` | New — contributor guide for adding changesets |