### PR TITLE
feat(leaderboard): add maintainer leaderboard page and backend API

### DIFF
--- a/packages/backend/src/controllers/statsController.ts
+++ b/packages/backend/src/controllers/statsController.ts
@@ -27,6 +27,13 @@ export interface GlobalStatsResponse {
   cacheExpiresAt: string;
 }
 
+export interface TopMaintainer {
+  address: string;
+  totalEarningsXlm: string;
+  totalEarningsStroops: string;
+  organizationsAssisted: number;
+}
+
 function stroopsToXlm(stroops: bigint): string {
   return (Number(stroops) / 10_000_000).toFixed(7);
 }
@@ -128,6 +135,55 @@ export const statsController = {
     await safeSet(cacheKey, JSON.stringify(response), 60); // Cache for 1 minute
 
     return response;
+  },
+
+  /**
+   * Get top maintainers ranked by total earnings.
+   */
+  async getTopMaintainers(): Promise<TopMaintainer[]> {
+    const cacheKey = "stats:top-maintainers";
+    const cached = await safeGet(cacheKey);
+    if (cached) {
+      return JSON.parse(cached);
+    }
+
+    const orgs = await stellarService.readAllOrganizations();
+    const maintainerAddresses = new Set<string>();
+
+    // Collect all unique maintainer addresses
+    await Promise.all(
+      orgs.map(async (orgId) => {
+        const maintainers = await stellarService.readMaintainers(orgId);
+        maintainers.forEach((m) => maintainerAddresses.add(m));
+      })
+    );
+
+    // Fetch stats for each maintainer
+    const maintainersData = await Promise.all(
+      [...maintainerAddresses].map(async (address) => {
+        const stats = await stellarService.readProfileStats(address);
+        return {
+          address,
+          totalEarningsXlm: stats.totalXlm,
+          totalEarningsStroops: stats.totalStroops.toString(),
+          organizationsAssisted: stats.orgIds.length,
+          rawStroops: stats.totalStroops,
+        };
+      })
+    );
+
+    // Sort by earnings descending
+    const sorted = maintainersData
+      .sort((a, b) => {
+        if (b.rawStroops > a.rawStroops) return 1;
+        if (b.rawStroops < a.rawStroops) return -1;
+        return 0;
+      })
+      .map(({ rawStroops, ...rest }) => rest);
+
+    await safeSet(cacheKey, JSON.stringify(sorted), 300); // Cache for 5 minutes
+
+    return sorted;
   },
 } as const;
 

--- a/packages/backend/src/routes/stats.ts
+++ b/packages/backend/src/routes/stats.ts
@@ -115,4 +115,37 @@ export const statsRoutes: FastifyPluginAsync = async (fastify) => {
       return reply.send(data);
     }
   );
+
+  /**
+   * GET /top-maintainers
+   * Returns a ranked list of top maintainers by earnings.
+   *
+   * @example
+   * GET /api/stats/top-maintainers
+   */
+  fastify.get(
+    "/top-maintainers",
+    {
+      schema: {
+        response: {
+          200: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                address: { type: "string" },
+                totalEarningsXlm: { type: "string" },
+                totalEarningsStroops: { type: "string" },
+                organizationsAssisted: { type: "number" },
+              },
+            },
+          },
+        },
+      },
+    },
+    async (_request, reply) => {
+      const data = await statsController.getTopMaintainers();
+      return reply.send(data);
+    }
+  );
 };

--- a/packages/backend/src/services/stellarService.ts
+++ b/packages/backend/src/services/stellarService.ts
@@ -126,6 +126,43 @@ export class StellarService {
   }
 
   /**
+   * Read the list of all registered organization IDs.
+   * This method fetches all `org_registered` events from the contract.
+   */
+  async readAllOrganizations(): Promise<string[]> {
+    const startLedger = parseInt(process.env["PROFILE_START_LEDGER"] ?? "1", 10);
+    
+    // topic[0] = Symbol("VeryPrincess"), topic[1] = Symbol("org_registered")
+    const topic0 = nativeToScVal("VeryPrincess", { type: "symbol" }).toXDR("base64");
+    const topic1 = nativeToScVal("org_registered", { type: "symbol" }).toXDR("base64");
+
+    const eventsResponse = await this.rpcServer.getEvents({
+      startLedger,
+      filters: [
+        {
+          type: "contract",
+          contractIds: [CONTRACT_ID],
+          topics: [[topic0, topic1]],
+        },
+      ],
+      limit: 1000,
+    });
+
+    const orgIds = new Set<string>();
+    for (const event of eventsResponse.events ?? []) {
+      try {
+        // topic[2] = orgId Symbol
+        const orgId = scValToNative(event.topic[2]) as string;
+        orgIds.add(orgId);
+      } catch {
+        // Skip malformed events
+      }
+    }
+
+    return [...orgIds];
+  }
+
+  /**
    * Read the list of maintainer addresses for an organization.
    *
    * @param orgId — The Symbol ID of the organization.

--- a/packages/frontend/src/app/[lang]/dashboard/page.tsx
+++ b/packages/frontend/src/app/[lang]/dashboard/page.tsx
@@ -78,6 +78,12 @@ function DashboardPageInner({ dictionary, lang }: { dictionary: Dictionary; lang
             >
               {dictionary.common.dashboard}
             </Link>
+            <Link
+              href={`/${lang}/leaderboard`}
+              className="text-sm font-medium text-white/60 transition-colors hover:text-white"
+            >
+              {dictionary.navigation.leaderboard}
+            </Link>
             <LanguageSwitcher currentLocale={lang} />
             <WalletButton />
           </div>

--- a/packages/frontend/src/app/[lang]/leaderboard/page.tsx
+++ b/packages/frontend/src/app/[lang]/leaderboard/page.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { GlassPanel } from "@/components/GlassPanel";
+import { GlassButton } from "@/components/GlassButton";
+import { fetchTopMaintainers, type TopMaintainer } from "@/lib/api";
+import { Locale } from "@/lib/i18n";
+import { getDictionary } from "@/lib/getDictionary";
+import type { Dictionary } from "@/lib/getDictionary";
+
+interface LeaderboardPageProps {
+  params: {
+    lang: Locale;
+  };
+}
+
+export default function LeaderboardPage({ params }: LeaderboardPageProps) {
+  const [maintainers, setMaintainers] = useState<TopMaintainer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dictionary, setDictionary] = useState<Dictionary | null>(null);
+  const [copiedAddress, setCopiedAddress] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadData() {
+      try {
+        const [data, dict] = await Promise.all([
+          fetchTopMaintainers(),
+          getDictionary(params.lang),
+        ]);
+        setMaintainers(data);
+        setDictionary(dict);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load leaderboard");
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadData();
+  }, [params.lang]);
+
+  const truncateAddress = (address: string) => {
+    if (!address) return "";
+    return `${address.slice(0, 4)}...${address.slice(-4)}`;
+  };
+
+  const handleCopy = (address: string) => {
+    navigator.clipboard.writeText(address);
+    setCopiedAddress(address);
+    setTimeout(() => setCopiedAddress(null), 2000);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-stellar-blue">
+        <div className="text-xl font-medium text-white/60 animate-pulse">
+          {dictionary?.common.loading || "Loading..."}
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !dictionary) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-stellar-blue">
+        <div className="text-xl font-medium text-red-400">
+          {error || "An error occurred"}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-stellar-blue px-6 py-12 md:py-24">
+      <div className="mx-auto max-w-5xl">
+        {/* Header */}
+        <div className="mb-12 text-center animate-fade-in">
+          <h1 className="mb-4 text-4xl font-bold tracking-tight text-white md:text-5xl lg:text-6xl">
+            {dictionary.leaderboard.title}
+          </h1>
+          <p className="mx-auto max-w-2xl text-lg text-white/60">
+            {dictionary.leaderboard.description}
+          </p>
+        </div>
+
+        {/* Leaderboard Table */}
+        <GlassPanel className="overflow-hidden border border-white/10 shadow-2xl">
+          <div className="overflow-x-auto">
+            <table className="w-full text-left">
+              <thead>
+                <tr className="border-b border-white/10 bg-white/5 text-sm font-semibold uppercase tracking-wider text-white/40">
+                  <th className="px-6 py-4">{dictionary.leaderboard.rank}</th>
+                  <th className="px-6 py-4">{dictionary.leaderboard.maintainer}</th>
+                  <th className="px-6 py-4 text-right">{dictionary.leaderboard.orgs_assisted}</th>
+                  <th className="px-6 py-4 text-right">{dictionary.leaderboard.earnings}</th>
+                  <th className="px-6 py-4 text-center">{dictionary.dashboard.actions}</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/10">
+                {maintainers.length === 0 ? (
+                  <tr>
+                    <td colSpan={5} className="px-6 py-12 text-center text-white/40">
+                      No maintainers found yet.
+                    </td>
+                  </tr>
+                ) : (
+                  maintainers.map((maintainer, index) => (
+                    <tr 
+                      key={maintainer.address} 
+                      className="group transition-colors hover:bg-white/5"
+                    >
+                      <td className="px-6 py-6">
+                        <div className={`flex h-8 w-8 items-center justify-center rounded-full font-bold ${
+                          index === 0 ? "bg-yellow-400/20 text-yellow-400" :
+                          index === 1 ? "bg-slate-300/20 text-slate-300" :
+                          index === 2 ? "bg-amber-600/20 text-amber-600" :
+                          "bg-white/5 text-white/40"
+                        }`}>
+                          {index + 1}
+                        </div>
+                      </td>
+                      <td className="px-6 py-6">
+                        <div className="flex flex-col">
+                          <span className="font-mono text-sm font-medium text-white">
+                            {truncateAddress(maintainer.address)}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-6 py-6 text-right">
+                        <span className="rounded-full bg-stellar-purple/10 px-3 py-1 text-xs font-semibold text-stellar-purple border border-stellar-purple/20">
+                          {maintainer.organizationsAssisted}
+                        </span>
+                      </td>
+                      <td className="px-6 py-6 text-right">
+                        <div className="flex flex-col items-end">
+                          <span className="text-lg font-bold text-stellar-teal">
+                            {maintainer.totalEarningsXlm} XLM
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-6 py-6 text-center">
+                        <GlassButton
+                          variant="secondary"
+                          onClick={() => handleCopy(maintainer.address)}
+                          className="!px-3 !py-1.5 text-xs"
+                        >
+                          {copiedAddress === maintainer.address 
+                            ? dictionary.leaderboard.address_copied 
+                            : dictionary.leaderboard.copy_address}
+                        </GlassButton>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </GlassPanel>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/app/[lang]/page.tsx
+++ b/packages/frontend/src/app/[lang]/page.tsx
@@ -70,6 +70,12 @@ export default async function HomePage({ params }: HomePageProps) {
             >
               {dictionary.navigation.dashboard}
             </Link>
+            <Link
+              href={`/${params.lang}/leaderboard`}
+              className="text-sm font-medium text-white/60 transition-colors hover:text-white"
+            >
+              {dictionary.navigation.leaderboard}
+            </Link>
             <LanguageSwitcher currentLocale={params.lang} />
             <WalletButton />
           </div>

--- a/packages/frontend/src/app/dashboard/page.tsx
+++ b/packages/frontend/src/app/dashboard/page.tsx
@@ -199,6 +199,9 @@ function DashboardPageInner() {
                 </p>
               </div>
               <div className="flex items-center gap-4">
+                <Link href="/leaderboard" className="text-sm text-white/60 hover:text-white transition-all">
+                  Leaderboard
+                </Link>
                 <Link href="/organizations" className="text-sm text-stellar-teal hover:underline transition-all">
                   Browse Organizations →
                 </Link>

--- a/packages/frontend/src/dictionaries/en.json
+++ b/packages/frontend/src/dictionaries/en.json
@@ -13,6 +13,7 @@
   },
   "navigation": {
     "dashboard": "Dashboard",
+    "leaderboard": "Leaderboard",
     "github": "View on GitHub",
     "stellar_network": "Stellar Network",
     "drips": "Drips"
@@ -92,5 +93,16 @@
     "english": "English",
     "spanish": "Español",
     "japanese": "日本語"
+  },
+  "leaderboard": {
+    "title": "Maintainer Leaderboard",
+    "description": "Celebrating the most active and high-earning maintainers across the ecosystem.",
+    "rank": "Rank",
+    "maintainer": "Maintainer",
+    "earnings": "All-Time Earnings",
+    "orgs_assisted": "Orgs Assisted",
+    "copy_address": "Copy Address",
+    "address_copied": "Address copied!",
+    "total_payouts": "Total Payouts"
   }
 }

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -3,7 +3,7 @@
  * @description Backend API client for very-princess.
  */
 
-const BACKEND_URL = process.env["NEXT_PUBLIC_BACKEND_URL"] ?? "http://localhost:3001/api/v1/contract";
+const BACKEND_URL = process.env["NEXT_PUBLIC_BACKEND_URL"] ?? "http://localhost:3001/api";
 
 export interface Org {
   id: string;
@@ -34,9 +34,27 @@ export async function fetchOrganizations(page: number = 1, limit: number = 10, s
     params.append('search', search);
   }
   
-  const response = await fetch(`${BACKEND_URL}/orgs?${params}`);
+  const response = await fetch(`${BACKEND_URL}/v1/contract/orgs?${params}`);
   if (!response.ok) {
     throw new Error(`Failed to fetch organizations: ${response.statusText}`);
+  }
+  return response.json();
+}
+
+export interface TopMaintainer {
+  address: string;
+  totalEarningsXlm: string;
+  totalEarningsStroops: string;
+  organizationsAssisted: number;
+}
+
+/**
+ * Fetch top maintainers from the backend.
+ */
+export async function fetchTopMaintainers(): Promise<TopMaintainer[]> {
+  const response = await fetch(`${BACKEND_URL}/stats/top-maintainers`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch leaderboard: ${response.statusText}`);
   }
   return response.json();
 }
@@ -50,7 +68,7 @@ export async function registerOrganization(
   admin: string,
   signerSecret: string
 ): Promise<{ success: boolean; transactionHash?: string }> {
-  const response = await fetch(`${BACKEND_URL}/orgs`, {
+  const response = await fetch(`${BACKEND_URL}/v1/contract/orgs`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ id, name, admin, signerSecret }),


### PR DESCRIPTION
closes #155 
- Create leaderboard page with ranking table showing maintainers by earnings
- Add navigation links to leaderboard in dashboard and header
- Implement backend endpoint to fetch top maintainers from contract data
- Add dictionary entries for internationalization support
- Include copy address functionality for maintainer wallet addresses